### PR TITLE
fix(progress card styles): 🐛  align destination text to right for [Delivers #171927673]

### DIFF
--- a/src/Containers/RideProgressCard/Components/RideInfo/RideInfo.tsx
+++ b/src/Containers/RideProgressCard/Components/RideInfo/RideInfo.tsx
@@ -38,8 +38,8 @@ class RideInfo extends React.PureComponent<Props> {
           </View>
         ) : null}
         <View style={rideInfoStyles.destinationContainer}>
-          <Text style={styles.mainText}>{destinationPrimaryText}</Text>
-          <Text style={styles.secondaryText}>{destinationSecondaryText}</Text>
+          <Text style={rideInfoStyles.destinationMainText}>{destinationPrimaryText}</Text>
+          <Text style={rideInfoStyles.destinationSecondaryText}>{destinationSecondaryText}</Text>
         </View>
       </View>
     );
@@ -53,6 +53,8 @@ class RideInfo extends React.PureComponent<Props> {
         extraRideInfoContainer: styles.extraRideInfoHorizontalContainer,
         originContainer: styles.originContainer,
         destinationContainer: styles.destinationHorizontalContainer,
+        destinationMainText: styles.mainTextDestination,
+        destinationSecondaryText: styles.secondaryTextDestination,
       };
     }
     return {
@@ -60,6 +62,8 @@ class RideInfo extends React.PureComponent<Props> {
       extraRideInfoContainer: styles.extraRideInfoVerticalContainer,
       originContainer: styles.originContainer,
       destinationContainer: styles.destinationVerticalContainer,
+      destinationMainText: styles.mainText,
+      destinationSecondaryText: styles.secondaryText,
     };
   };
 }
@@ -74,6 +78,7 @@ const getStyles = ({ fonts }: ThemeParamsType) => {
     originContainer: {
       flexGrow: 1,
       flexBasis: 0,
+      textAlign: "left",
     },
     extraRideInfoHorizontalContainer: { alignItems: "center" },
     extraRideInfoVerticalContainer: { justifyContent: "center" },
@@ -83,8 +88,10 @@ const getStyles = ({ fonts }: ThemeParamsType) => {
       alignItems: "flex-end",
     },
     destinationVerticalContainer: { flex: 1, justifyContent: "flex-end" },
-    mainText: fonts.BodyRegular,
-    secondaryText: fonts.BodySmall,
+    mainText: { ...fonts.BodyRegular, textAlign: "left" },
+    secondaryText: { ...fonts.BodySmall, textAlign: "left" },
+    mainTextDestination: { ...fonts.BodyRegular, textAlign: "right" },
+    secondaryTextDestination: { ...fonts.BodySmall, textAlign: "right" },
   });
 };
 export default withTheme<Props>(getStyles)(RideInfo);

--- a/src/Containers/RideProgressCard/Components/RideInfo/RideInfo.tsx
+++ b/src/Containers/RideProgressCard/Components/RideInfo/RideInfo.tsx
@@ -78,7 +78,6 @@ const getStyles = ({ fonts }: ThemeParamsType) => {
     originContainer: {
       flexGrow: 1,
       flexBasis: 0,
-      textAlign: "left",
     },
     extraRideInfoHorizontalContainer: { alignItems: "center" },
     extraRideInfoVerticalContainer: { justifyContent: "center" },


### PR DESCRIPTION
…izontal [#171927673]

align destination text to right for horizontal progress line, and align
origin text to left

*`alignText: start | end` doesn't work for react-native
*`alignText: left | right` work nice both left to right and RTL cases